### PR TITLE
Code Cleanup

### DIFF
--- a/DebugConnectionProvider.cs
+++ b/DebugConnectionProvider.cs
@@ -1,40 +1,24 @@
 using System;
 using System.Collections;
 using System.Data;
+
 using Iesi.Collections;
+
 using NHibernate.Connection;
 
 namespace NHibernate.Test
 {
 	/// <summary>
-	/// This connection provider keeps a list of all open connections,
-	/// it is used when testing to check that tests clean up after themselves.
+	/// This connection provider keeps a list of all open connections, it is used when testing to check that tests clean up after
+	/// themselves.
 	/// </summary>
 	public class DebugConnectionProvider : DriverConnectionProvider
 	{
-		private ISet connections = new ListSet();
+		private readonly ISet connections = new ListSet();
 
-		public override IDbConnection GetConnection()
-		{
-		    try
-		    {
-		        IDbConnection connection = base.GetConnection();
-                connections.Add(connection);
-                return connection;
-            }
-		    catch (Exception e)
-		    {
-		        throw new HibernateException("Could not open connection to: " + ConnectionString, e);
-		    }
-		    
-		}
-
-		public override void CloseConnection(IDbConnection conn)
-		{
-			base.CloseConnection(conn);
-			connections.Remove(conn);
-		}
-
+		/// <summary>
+		/// Gets a value indicating whether this object has open connections.
+		/// </summary>
 		public bool HasOpenConnections
 		{
 			get
@@ -42,39 +26,70 @@ namespace NHibernate.Test
 				// check to see if all connections that were at one point opened
 				// have been closed through the CloseConnection
 				// method
-				if (connections.IsEmpty)
+				if (this.connections.IsEmpty)
 				{
 					// there are no connections, either none were opened or
 					// all of the closings went through CloseConnection.
 					return false;
 				}
-				else
-				{
-					// Disposing of an ISession does not call CloseConnection (should it???)
-					// so a Diposed of ISession will leave an IDbConnection in the list but
-					// the IDbConnection will be closed (atleast with MsSql it works this way).
-					foreach (IDbConnection conn in connections)
-					{
-						if (conn.State != ConnectionState.Closed)
-						{
-							return true;
-						}
-					}
 
-					// all of the connections have been Disposed and were closed that way
-					// or they were Closed through the CloseConnection method.
-					return false;
+				// Disposing of an ISession does not call CloseConnection (should it???)
+				// so a Diposed of ISession will leave an IDbConnection in the list but
+				// the IDbConnection will be closed (atleast with MsSql it works this way).
+				foreach (IDbConnection conn in this.connections)
+				{
+					if (conn.State != ConnectionState.Closed)
+					{
+						return true;
+					}
 				}
+
+				// all of the connections have been Disposed and were closed that way
+				// or they were Closed through the CloseConnection method.
+				return false;
 			}
 		}
 
+		/// <summary>
+		/// Closes all connections.
+		/// </summary>
 		public void CloseAllConnections()
 		{
-			while (!connections.IsEmpty)
+			while (!this.connections.IsEmpty)
 			{
-				IEnumerator en = connections.GetEnumerator();
+				IEnumerator en = this.connections.GetEnumerator();
 				en.MoveNext();
-				CloseConnection(en.Current as IDbConnection);
+				this.CloseConnection(en.Current as IDbConnection);
+			}
+		}
+
+		/// <summary>
+		/// Closes a connection.
+		/// </summary>
+		/// <param name="conn">The connection.</param>
+		public override void CloseConnection(IDbConnection conn)
+		{
+			base.CloseConnection(conn);
+			this.connections.Remove(conn);
+		}
+
+		/// <summary>
+		/// Gets the connection.
+		/// </summary>
+		/// <returns>
+		/// The connection.
+		/// </returns>
+		public override IDbConnection GetConnection()
+		{
+			try
+			{
+				IDbConnection connection = base.GetConnection();
+				this.connections.Add(connection);
+				return connection;
+			}
+			catch (Exception e)
+			{
+				throw new HibernateException("Could not open connection to: " + this.ConnectionString, e);
 			}
 		}
 	}

--- a/NHSpecificTest/BugTestCase.cs
+++ b/NHSpecificTest/BugTestCase.cs
@@ -1,38 +1,46 @@
-using System;
 using System.Collections;
 
 namespace NHibernate.Test.NHSpecificTest
 {
 	/// <summary>
-	/// Base class that can be used for tests in NH* subdirectories.
-	/// Assumes all mappings are in a single file named <c>Mappings.hbm.xml</c>
+	/// Base class that can be used for tests in NH* subdirectories. Assumes all mappings are in a single file named
+	/// <c>Mappings.hbm.xml</c>
 	/// in the subdirectory.
 	/// </summary>
 	public abstract class BugTestCase : TestCase
 	{
-		protected override string MappingsAssembly
-		{
-			get { return "NHibernate.Test"; }
-		}
-
+		/// <summary>
+		/// Gets the bug number.
+		/// </summary>
 		public virtual string BugNumber
 		{
 			get
 			{
-				string ns = GetType().Namespace;
+				string ns = this.GetType().Namespace;
 				return ns.Substring(ns.LastIndexOf('.') + 1);
 			}
 		}
 
+		/// <summary>
+		/// Mapping files used in the TestCase.
+		/// </summary>
 		protected override IList Mappings
 		{
 			get
 			{
-				return new string[]
-					{
-						"NHSpecificTest." + BugNumber + ".Mappings.hbm.xml"
-					};
+				return new[]
+				{
+					"NHSpecificTest." + this.BugNumber + ".Mappings.hbm.xml"
+				};
 			}
+		}
+
+		/// <summary>
+		/// Assembly to load mapping files from (default is NHibernate.DomainModel).
+		/// </summary>
+		protected override string MappingsAssembly
+		{
+			get { return "NHibernate.Test"; }
 		}
 	}
 }

--- a/NHSpecificTest/NH1234/DomainClass.cs
+++ b/NHSpecificTest/NH1234/DomainClass.cs
@@ -1,22 +1,8 @@
-﻿
-
-namespace NHibernate.Test.NHSpecificTest.NH1234
+﻿namespace NHibernate.Test.NHSpecificTest.NH1234
 {
-    public class DomainClass
-    {
-        private byte[] byteData;
-        private int id;
-
-        public int Id
-        {
-            get { return id; }
-            set { id = value; }
-        }
-
-        public byte[] ByteData
-        {
-            get { return byteData; }
-            set { byteData = value; }
-        }
-    }
+	public class DomainClass
+	{
+		public byte[] ByteData { get; set; }
+		public int Id { get; set; }
+	}
 }

--- a/NHSpecificTest/NH1234/SampleTest.cs
+++ b/NHSpecificTest/NH1234/SampleTest.cs
@@ -1,56 +1,53 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Text;
-using NHibernate.Dialect;
+﻿using NHibernate.Dialect;
+
 using NUnit.Framework;
 
 namespace NHibernate.Test.NHSpecificTest.NH1234
 {
-    [TestFixture]
-    public class SampleTest : BugTestCase
-    {
-        protected override void OnSetUp()
-        {
-            base.OnSetUp();
-            using (ISession session = this.OpenSession())
-            {
-                DomainClass entity = new DomainClass();
-                entity.Id = 1;
-                entity.ByteData = new byte[] {1, 2, 3};
-                session.Save(entity);
-                session.Flush();
-            }
-        }
+	[TestFixture]
+	public class SampleTest : BugTestCase
+	{
+		[Test]
+		public void BytePropertyShouldBeRetrievedCorrectly()
+		{
+			using (ISession session = this.OpenSession())
+			{
+				DomainClass entity = session.Get<DomainClass>(1);
 
-        protected override void OnTearDown()
-        {
-            base.OnTearDown();
-            using (ISession session = this.OpenSession())
-            {
-                string hql = "from System.Object";
-                session.Delete(hql);
-                session.Flush();
-            }
-        }
+				Assert.AreEqual(3, entity.ByteData.Length);
+				Assert.AreEqual(1, entity.ByteData[0]);
+				Assert.AreEqual(2, entity.ByteData[1]);
+				Assert.AreEqual(3, entity.ByteData[2]);
+			}
+		}
 
-        protected override bool AppliesTo(NHibernate.Dialect.Dialect dialect)
-        {
-            return dialect as MsSql2005Dialect != null;
-        }
+		protected override bool AppliesTo(Dialect.Dialect dialect)
+		{
+			return dialect as MsSql2005Dialect != null;
+		}
 
-        [Test]
-        public void BytePropertyShouldBeRetrievedCorrectly()
-        {
-            using (ISession session = this.OpenSession())
-            {
-                DomainClass entity = session.Get<DomainClass>(1);
+		protected override void OnSetUp()
+		{
+			base.OnSetUp();
+			using (ISession session = this.OpenSession())
+			{
+				DomainClass entity = new DomainClass();
+				entity.Id = 1;
+				entity.ByteData = new byte[] { 1, 2, 3 };
+				session.Save(entity);
+				session.Flush();
+			}
+		}
 
-                Assert.AreEqual(3, entity.ByteData.Length);
-                Assert.AreEqual(1, entity.ByteData[0]);
-                Assert.AreEqual(2, entity.ByteData[1]);
-                Assert.AreEqual(3, entity.ByteData[2]);
-            }
-        }
-    }
+		protected override void OnTearDown()
+		{
+			base.OnTearDown();
+			using (ISession session = this.OpenSession())
+			{
+				string hql = "from System.Object";
+				session.Delete(hql);
+				session.Flush();
+			}
+		}
+	}
 }

--- a/NHibernate.Test-Lite.csproj
+++ b/NHibernate.Test-Lite.csproj
@@ -94,7 +94,9 @@
     <Compile Include="TestDialect.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{B4F97281-0DBD-4835-9ED8-7DFB966E87FF}" />
@@ -122,6 +124,7 @@
   <ItemGroup>
     <Content Include="hibernate.cfg.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/TestCase.cs
+++ b/TestCase.cs
@@ -2,392 +2,471 @@ using System;
 using System.Collections;
 using System.Data;
 using System.Reflection;
-using log4net;
-using log4net.Config;
+
 using NHibernate.Cfg;
 using NHibernate.Connection;
 using NHibernate.Engine;
+using NHibernate.Hql.Ast.ANTLR;
+using NHibernate.Hql.Classic;
 using NHibernate.Mapping;
 using NHibernate.Tool.hbm2ddl;
 using NHibernate.Type;
+
 using NUnit.Framework;
-using NHibernate.Hql.Classic;
-using NHibernate.Hql.Ast.ANTLR;
+
+using log4net;
+using log4net.Config;
 
 namespace NHibernate.Test
 {
-    public abstract class TestCase
-    {
-        private const bool OutputDdl = false;
-        protected Configuration cfg;
-        protected ISessionFactoryImplementor sessions;
+	public abstract class TestCase
+	{
+		protected Configuration cfg;
+		protected ISession lastOpenedSession;
+		protected ISessionFactoryImplementor sessions;
+		private const bool OutputDdl = false;
 
-        private static readonly ILog log = LogManager.GetLogger(typeof(TestCase));
+		private static readonly ILog log = LogManager.GetLogger(typeof(TestCase));
+		private DebugConnectionProvider connectionProvider;
 
-        protected Dialect.Dialect Dialect
-        {
-            get { return NHibernate.Dialect.Dialect.GetDialect(cfg.Properties); }
-        }
+		static TestCase()
+		{
+			// Configure log4net here since configuration through an attribute doesn't always work.
+			XmlConfigurator.Configure();
+		}
 
-        protected TestDialect TestDialect
-        {
-            get { return TestDialect.GetTestDialect(Dialect); }
-        }
+		/// <summary>
+		/// Gets the cache concurrency strategy.
+		/// </summary>
+		protected virtual string CacheConcurrencyStrategy
+		{
+			get { return "nonstrict-read-write"; }
+			//get { return null; }
+		}
 
-        /// <summary>
-        /// To use in in-line test
-        /// </summary>
-        protected bool IsClassicParser
-        {
-            get
-            {
-                return sessions.Settings.QueryTranslatorFactory is ClassicQueryTranslatorFactory;
-            }
-        }
+		/// <summary>
+		/// Gets the dialect.
+		/// </summary>
+		protected Dialect.Dialect Dialect
+		{
+			get { return NHibernate.Dialect.Dialect.GetDialect(this.cfg.Properties); }
+		}
 
-        /// <summary>
-        /// To use in in-line test
-        /// </summary>
-        protected bool IsAntlrParser
-        {
-            get
-            {
-                return sessions.Settings.QueryTranslatorFactory is ASTQueryTranslatorFactory;
-            }
-        }
+		/// <summary>
+		/// To use in in-line test.
+		/// </summary>
+		protected bool IsAntlrParser
+		{
+			get { return this.sessions.Settings.QueryTranslatorFactory is ASTQueryTranslatorFactory; }
+		}
 
-        protected ISession lastOpenedSession;
-        private DebugConnectionProvider connectionProvider;
+		/// <summary>
+		/// To use in in-line test
+		/// </summary>
+		protected bool IsClassicParser
+		{
+			get { return this.sessions.Settings.QueryTranslatorFactory is ClassicQueryTranslatorFactory; }
+		}
 
-        /// <summary>
-        /// Mapping files used in the TestCase
-        /// </summary>
-        protected abstract IList Mappings { get; }
+		/// <summary>
+		/// Mapping files used in the TestCase
+		/// </summary>
+		protected abstract IList Mappings { get; }
 
-        /// <summary>
-        /// Assembly to load mapping files from (default is NHibernate.DomainModel).
-        /// </summary>
-        protected virtual string MappingsAssembly
-        {
-            get { return "NHibernate.DomainModel"; }
-        }
+		/// <summary>
+		/// Assembly to load mapping files from (default is NHibernate.DomainModel).
+		/// </summary>
+		protected virtual string MappingsAssembly
+		{
+			get { return "NHibernate.DomainModel"; }
+		}
 
-        static TestCase()
-        {
-            // Configure log4net here since configuration through an attribute doesn't always work.
-            XmlConfigurator.Configure();
-        }
+		/// <summary>
+		/// Gets the Session Factory Implementor.
+		/// </summary>
+		protected ISessionFactoryImplementor Sfi
+		{
+			get { return this.sessions; }
+		}
 
-        /// <summary>
-        /// Creates the tables used in this TestCase
-        /// </summary>
-        [TestFixtureSetUp]
-        public void TestFixtureSetUp()
-        {
-            try
-            {
-                Configure();
-                if (!AppliesTo(Dialect))
-                {
-                    Assert.Ignore(GetType() + " does not apply to " + Dialect);
-                }
+		/// <summary>
+		/// Gets the test dialect.
+		/// </summary>
+		protected TestDialect TestDialect
+		{
+			get { return TestDialect.GetTestDialect(this.Dialect); }
+		}
 
-                CreateSchema();
-                try
-                {
-                    BuildSessionFactory();
-                    if (!AppliesTo(sessions))
-                    {
-                        Assert.Ignore(GetType() + " does not apply with the current session-factory configuration");
-                    }
-                }
-                catch
-                {
-                    DropSchema();
-                    throw;
-                }
-            }
-            catch (Exception e)
-            {
-                Cleanup();
-                log.Error("Error while setting up the test fixture", e);
-                throw;
-            }
-        }
+		/// <summary>
+		/// Executes the Sql statement.
+		/// </summary>
+		/// <param name="sql">The sql statement.</param>
+		/// <returns>
+		/// The number of rows effected.
+		/// </returns>
+		public int ExecuteStatement(string sql)
+		{
+			if (this.cfg == null)
+			{
+				this.cfg = new Configuration();
+			}
 
-        /// <summary>
-        /// Removes the tables used in this TestCase.
-        /// </summary>
-        /// <remarks>
-        /// If the tables are not cleaned up sometimes SchemaExport runs into
-        /// Sql errors because it can't drop tables because of the FKs.  This 
-        /// will occur if the TestCase does not have the same hbm.xml files
-        /// included as a previous one.
-        /// </remarks>
-        [TestFixtureTearDown]
-        public void TestFixtureTearDown()
-        {
-            if (!AppliesTo(Dialect))
-                return;
+			using (IConnectionProvider prov = ConnectionProviderFactory.NewConnectionProvider(this.cfg.Properties))
+			{
+				IDbConnection conn = prov.GetConnection();
 
-            DropSchema();
-            Cleanup();
-        }
+				try
+				{
+					using (IDbTransaction tran = conn.BeginTransaction())
+					{
+						using (IDbCommand comm = conn.CreateCommand())
+						{
+							comm.CommandText = sql;
+							comm.Transaction = tran;
+							comm.CommandType = CommandType.Text;
+							int result = comm.ExecuteNonQuery();
+							tran.Commit();
+							return result;
+						}
+					}
+				}
+				finally
+				{
+					prov.CloseConnection(conn);
+				}
+			}
+		}
 
-        protected virtual void OnSetUp()
-        {
-        }
+		/// <summary>
+		/// Executes the Sql statement.
+		/// </summary>
+		/// <param name="session">The session.</param>
+		/// <param name="transaction">The transaction.</param>
+		/// <param name="sql">The sql statement.</param>
+		/// <returns>
+		/// The number of rows effected.
+		/// </returns>
+		public int ExecuteStatement(ISession session, ITransaction transaction, string sql)
+		{
+			using (IDbCommand cmd = session.Connection.CreateCommand())
+			{
+				cmd.CommandText = sql;
+				if (transaction != null)
+				{
+					transaction.Enlist(cmd);
+				}
+				return cmd.ExecuteNonQuery();
+			}
+		}
 
-        /// <summary>
-        /// Set up the test. This method is not overridable, but it calls
-        /// <see cref="OnSetUp" /> which is.
-        /// </summary>
-        [SetUp]
-        public void SetUp()
-        {
-            OnSetUp();
-        }
+		/// <summary>
+		/// Set up the test. This method is not overridable, but it calls <see cref="OnSetUp" /> which is.
+		/// </summary>
+		[SetUp]
+		public void SetUp()
+		{
+			this.OnSetUp();
+		}
 
-        protected virtual void OnTearDown()
-        {
-        }
+		/// <summary>
+		/// Checks that the test case cleans up after itself. This method is not overridable, but it calls <see cref="OnTearDown" />
+		/// which is.
+		/// </summary>
+		[TearDown]
+		public void TearDown()
+		{
+			this.OnTearDown();
 
-        /// <summary>
-        /// Checks that the test case cleans up after itself. This method
-        /// is not overridable, but it calls <see cref="OnTearDown" /> which is.
-        /// </summary>
-        [TearDown]
-        public void TearDown()
-        {
-            OnTearDown();
+			bool wasClosed = this.CheckSessionWasClosed();
+			bool wasCleaned = this.CheckDatabaseWasCleaned();
+			bool wereConnectionsClosed = this.CheckConnectionsWereClosed();
+			bool fail = !wasClosed || !wasCleaned || !wereConnectionsClosed;
 
-            bool wasClosed = CheckSessionWasClosed();
-            bool wasCleaned = CheckDatabaseWasCleaned();
-            bool wereConnectionsClosed = CheckConnectionsWereClosed();
-            bool fail = !wasClosed || !wasCleaned || !wereConnectionsClosed;
+			if (fail)
+			{
+				Assert.Fail(
+					"Test didn't clean up after itself. session closed: " + wasClosed + " database cleaned: " + wasCleaned
+					+ " connection closed: " + wereConnectionsClosed);
+			}
+		}
 
-            if (fail)
-            {
-                Assert.Fail("Test didn't clean up after itself. session closed: " + wasClosed + " database cleaned: " + wasCleaned
-                    + " connection closed: " + wereConnectionsClosed);
-            }
-        }
+		/// <summary>
+		/// Creates the tables used in this TestCase.
+		/// </summary>
+		[TestFixtureSetUp]
+		public void TestFixtureSetUp()
+		{
+			try
+			{
+				this.Configure();
+				if (!this.AppliesTo(this.Dialect))
+				{
+					Assert.Ignore(this.GetType() + " does not apply to " + this.Dialect);
+				}
 
-        private bool CheckSessionWasClosed()
-        {
-            if (lastOpenedSession != null && lastOpenedSession.IsOpen)
-            {
-                log.Error("Test case didn't close a session, closing");
-                lastOpenedSession.Close();
-                return false;
-            }
+				this.CreateSchema();
+				try
+				{
+					this.BuildSessionFactory();
+					if (!this.AppliesTo(this.sessions))
+					{
+						Assert.Ignore(this.GetType() + " does not apply with the current session-factory configuration");
+					}
+				}
+				catch
+				{
+					this.DropSchema();
+					throw;
+				}
+			}
+			catch (Exception e)
+			{
+				this.Cleanup();
+				log.Error("Error while setting up the test fixture", e);
+				throw;
+			}
+		}
 
-            return true;
-        }
+		/// <summary>
+		/// Removes the tables used in this TestCase.
+		/// </summary>
+		/// <remarks>
+		/// If the tables are not cleaned up sometimes SchemaExport runs into Sql errors because it can't drop tables because of the FKs.
+		/// This will occur if the TestCase does not have the same hbm.xml files included as a previous one.
+		/// </remarks>
+		[TestFixtureTearDown]
+		public void TestFixtureTearDown()
+		{
+			if (!this.AppliesTo(this.Dialect))
+			{
+				return;
+			}
 
-        private bool CheckDatabaseWasCleaned()
-        {
-            if (sessions.GetAllClassMetadata().Count == 0)
-            {
-                // Return early in the case of no mappings, also avoiding
-                // a warning when executing the HQL below.
-                return true;
-            }
+			this.DropSchema();
+			this.Cleanup();
+		}
 
-            bool empty;
-            using (ISession s = sessions.OpenSession())
-            {
-                IList objects = s.CreateQuery("from System.Object o").List();
-                empty = objects.Count == 0;
-            }
+		/// <summary>
+		/// Adds the hbm mappings as resource.
+		/// </summary>
+		/// <param name="configuration">The NHibernate configuration.</param>
+		protected virtual void AddMappings(Configuration configuration)
+		{
+			Assembly assembly = Assembly.Load(this.MappingsAssembly);
 
-            if (!empty)
-            {
-                log.Error("Test case didn't clean up the database after itself, re-creating the schema");
-                DropSchema();
-                CreateSchema();
-            }
+			foreach (string file in this.Mappings)
+			{
+				configuration.AddResource(this.MappingsAssembly + "." + file, assembly);
+			}
+		}
 
-            return empty;
-        }
+		/// <summary>
+		/// Whether the TestCase applies to a dialect. Override in subclasses to prevent those tests from running against a particular
+		/// dialect.
+		/// </summary>
+		/// <param name="dialect">The dialect.</param>
+		/// <returns>
+		/// true if the dialect should be tested, false if not.
+		/// </returns>
+		protected virtual bool AppliesTo(Dialect.Dialect dialect)
+		{
+			return true;
+		}
 
-        private bool CheckConnectionsWereClosed()
-        {
-            if (connectionProvider == null || !connectionProvider.HasOpenConnections)
-            {
-                return true;
-            }
+		/// <summary>
+		/// Whether the TestCase applies to a factory. Override in subclasses to prevent those tests from running against a particular
+		/// factory.
+		/// </summary>
+		/// <param name="factory">The factory.</param>
+		/// <returns>
+		/// true if the factory should be tested, false if not.
+		/// </returns>
+		protected virtual bool AppliesTo(ISessionFactoryImplementor factory)
+		{
+			return true;
+		}
 
-            log.Error("Test case didn't close all open connections, closing");
-            connectionProvider.CloseAllConnections();
-            return false;
-        }
+		/// <summary>
+		/// Applies the cache settings described by configuration.
+		/// </summary>
+		/// <param name="configuration">The NHibernate configuration.</param>
+		protected void ApplyCacheSettings(Configuration configuration)
+		{
+			if (this.CacheConcurrencyStrategy == null)
+			{
+				return;
+			}
 
-        private void Configure()
-        {
-            cfg = new Configuration();
-            if (TestConfigurationHelper.hibernateConfigFile != null)
-                cfg.Configure(TestConfigurationHelper.hibernateConfigFile);
+			foreach (PersistentClass clazz in configuration.ClassMappings)
+			{
+				bool hasLob = false;
+				foreach (Property prop in clazz.PropertyClosureIterator)
+				{
+					if (prop.Value.IsSimpleValue)
+					{
+						IType type = ((SimpleValue)prop.Value).Type;
+						if (type == NHibernateUtil.BinaryBlob)
+						{
+							hasLob = true;
+						}
+					}
+				}
+				if (!hasLob && !clazz.IsInherited)
+				{
+					configuration.SetCacheConcurrencyStrategy(clazz.EntityName, this.CacheConcurrencyStrategy);
+				}
+			}
 
-            AddMappings(cfg);
+			foreach (Mapping.Collection coll in configuration.CollectionMappings)
+			{
+				configuration.SetCollectionCacheConcurrencyStrategy(coll.Role, this.CacheConcurrencyStrategy);
+			}
+		}
 
-            Configure(cfg);
+		/// <summary>
+		/// Builds the session factory.
+		/// </summary>
+		protected virtual void BuildSessionFactory()
+		{
+			this.sessions = (ISessionFactoryImplementor)this.cfg.BuildSessionFactory();
+			this.connectionProvider = this.sessions.ConnectionProvider as DebugConnectionProvider;
+		}
 
-            ApplyCacheSettings(cfg);
-        }
+		/// <summary>
+		/// Configure NHibernate.
+		/// </summary>
+		/// <param name="configuration">The NHibernate configuration.</param>
+		protected virtual void Configure(Configuration configuration)
+		{
+		}
 
-        protected virtual void AddMappings(Configuration configuration)
-        {
-            Assembly assembly = Assembly.Load(MappingsAssembly);
+		/// <summary>
+		/// Creates the schema.
+		/// </summary>
+		protected virtual void CreateSchema()
+		{
+			new SchemaExport(this.cfg).Create(OutputDdl, true);
+		}
 
-            foreach (string file in Mappings)
-            {
-                configuration.AddResource(MappingsAssembly + "." + file, assembly);
-            }
-        }
+		/// <summary>
+		/// Executes the set up action.
+		/// </summary>
+		protected virtual void OnSetUp()
+		{
+		}
 
-        protected virtual void CreateSchema()
-        {
-            new SchemaExport(cfg).Create(OutputDdl, true);
-        }
+		/// <summary>
+		/// Executes the tear down action.
+		/// </summary>
+		protected virtual void OnTearDown()
+		{
+		}
 
-        private void DropSchema()
-        {
-            new SchemaExport(cfg).Drop(OutputDdl, true);
-        }
+		/// <summary>
+		/// Opens and returns the NHibernate session.
+		/// </summary>
+		/// <returns>
+		/// An <see cref="ISession"/>.
+		/// </returns>
+		protected virtual ISession OpenSession()
+		{
+			this.lastOpenedSession = this.sessions.OpenSession();
+			return this.lastOpenedSession;
+		}
 
-        protected virtual void BuildSessionFactory()
-        {
-            sessions = (ISessionFactoryImplementor)cfg.BuildSessionFactory();
-            connectionProvider = sessions.ConnectionProvider as DebugConnectionProvider;
-        }
+		/// <summary>
+		/// Opens and returns the NHibernate session.
+		/// </summary>
+		/// <param name="sessionLocalInterceptor">The local session interceptor.</param>
+		/// <returns>
+		/// An <see cref="ISession"/>.
+		/// </returns>
+		protected virtual ISession OpenSession(IInterceptor sessionLocalInterceptor)
+		{
+			this.lastOpenedSession = this.sessions.OpenSession(sessionLocalInterceptor);
+			return this.lastOpenedSession;
+		}
 
-        private void Cleanup()
-        {
-            if (sessions != null)
-            {
-                sessions.Close();
-            }
-            sessions = null;
-            connectionProvider = null;
-            lastOpenedSession = null;
-            cfg = null;
-        }
+		private bool CheckConnectionsWereClosed()
+		{
+			if (this.connectionProvider == null || !this.connectionProvider.HasOpenConnections)
+			{
+				return true;
+			}
 
-        public int ExecuteStatement(string sql)
-        {
-            if (cfg == null)
-            {
-                cfg = new Configuration();
-            }
+			log.Error("Test case didn't close all open connections, closing");
+			this.connectionProvider.CloseAllConnections();
+			return false;
+		}
 
-            using (IConnectionProvider prov = ConnectionProviderFactory.NewConnectionProvider(cfg.Properties))
-            {
-                IDbConnection conn = prov.GetConnection();
+		private bool CheckDatabaseWasCleaned()
+		{
+			if (this.sessions.GetAllClassMetadata().Count == 0)
+			{
+				// Return early in the case of no mappings, also avoiding
+				// a warning when executing the HQL below.
+				return true;
+			}
 
-                try
-                {
-                    using (IDbTransaction tran = conn.BeginTransaction())
-                    using (IDbCommand comm = conn.CreateCommand())
-                    {
-                        comm.CommandText = sql;
-                        comm.Transaction = tran;
-                        comm.CommandType = CommandType.Text;
-                        int result = comm.ExecuteNonQuery();
-                        tran.Commit();
-                        return result;
-                    }
-                }
-                finally
-                {
-                    prov.CloseConnection(conn);
-                }
-            }
-        }
+			bool empty;
+			using (ISession s = this.sessions.OpenSession())
+			{
+				IList objects = s.CreateQuery("from System.Object o").List();
+				empty = objects.Count == 0;
+			}
 
-        public int ExecuteStatement(ISession session, ITransaction transaction, string sql)
-        {
-            using (IDbCommand cmd = session.Connection.CreateCommand())
-            {
-                cmd.CommandText = sql;
-                if (transaction != null)
-                    transaction.Enlist(cmd);
-                return cmd.ExecuteNonQuery();
-            }
-        }
+			if (!empty)
+			{
+				log.Error("Test case didn't clean up the database after itself, re-creating the schema");
+				this.DropSchema();
+				this.CreateSchema();
+			}
 
-        protected ISessionFactoryImplementor Sfi
-        {
-            get { return sessions; }
-        }
+			return empty;
+		}
 
-        protected virtual ISession OpenSession()
-        {
-            lastOpenedSession = sessions.OpenSession();
-            return lastOpenedSession;
-        }
+		private bool CheckSessionWasClosed()
+		{
+			if (this.lastOpenedSession != null && this.lastOpenedSession.IsOpen)
+			{
+				log.Error("Test case didn't close a session, closing");
+				this.lastOpenedSession.Close();
+				return false;
+			}
 
-        protected virtual ISession OpenSession(IInterceptor sessionLocalInterceptor)
-        {
-            lastOpenedSession = sessions.OpenSession(sessionLocalInterceptor);
-            return lastOpenedSession;
-        }
+			return true;
+		}
 
-        protected void ApplyCacheSettings(Configuration configuration)
-        {
-            if (CacheConcurrencyStrategy == null)
-            {
-                return;
-            }
+		private void Cleanup()
+		{
+			if (this.sessions != null)
+			{
+				this.sessions.Close();
+			}
+			this.sessions = null;
+			this.connectionProvider = null;
+			this.lastOpenedSession = null;
+			this.cfg = null;
+		}
 
-            foreach (PersistentClass clazz in configuration.ClassMappings)
-            {
-                bool hasLob = false;
-                foreach (Property prop in clazz.PropertyClosureIterator)
-                {
-                    if (prop.Value.IsSimpleValue)
-                    {
-                        IType type = ((SimpleValue)prop.Value).Type;
-                        if (type == NHibernateUtil.BinaryBlob)
-                        {
-                            hasLob = true;
-                        }
-                    }
-                }
-                if (!hasLob && !clazz.IsInherited)
-                {
-                    configuration.SetCacheConcurrencyStrategy(clazz.EntityName, CacheConcurrencyStrategy);
-                }
-            }
+		private void Configure()
+		{
+			this.cfg = new Configuration();
+			if (TestConfigurationHelper.hibernateConfigFile != null)
+			{
+				this.cfg.Configure(TestConfigurationHelper.hibernateConfigFile);
+			}
 
-            foreach (Mapping.Collection coll in configuration.CollectionMappings)
-            {
-                configuration.SetCollectionCacheConcurrencyStrategy(coll.Role, CacheConcurrencyStrategy);
-            }
-        }
+			this.AddMappings(this.cfg);
 
-        #region Properties overridable by subclasses
+			this.Configure(this.cfg);
 
-        protected virtual bool AppliesTo(Dialect.Dialect dialect)
-        {
-            return true;
-        }
+			this.ApplyCacheSettings(this.cfg);
+		}
 
-        protected virtual bool AppliesTo(ISessionFactoryImplementor factory)
-        {
-            return true;
-        }
-
-        protected virtual void Configure(Configuration configuration)
-        {
-        }
-
-        protected virtual string CacheConcurrencyStrategy
-        {
-            get { return "nonstrict-read-write"; }
-            //get { return null; }
-        }
-
-        #endregion
-    }
+		private void DropSchema()
+		{
+			new SchemaExport(this.cfg).Drop(OutputDdl, true);
+		}
+	}
 }

--- a/TestConfigurationHelper.cs
+++ b/TestConfigurationHelper.cs
@@ -1,9 +1,10 @@
+using System;
+using System.IO;
+
+using NHibernate.Cfg;
+
 namespace NHibernate.Test
 {
-	using System;
-	using System.IO;
-	using Cfg;
-
 	public static class TestConfigurationHelper
 	{
 		public static readonly string hibernateConfigFile;
@@ -11,28 +12,38 @@ namespace NHibernate.Test
 		static TestConfigurationHelper()
 		{
 			// Verify if hibernate.cfg.xml exists
-			hibernateConfigFile = TestConfigurationHelper.GetDefaultConfigurationFilePath();
+			hibernateConfigFile = GetDefaultConfigurationFilePath();
 		}
 
+		/// <summary>
+		/// Standard Configuration for tests.
+		/// </summary>
+		/// <returns>
+		/// The configuration using merge between App.Config and hibernate.cfg.xml if present.
+		/// </returns>
+		public static Configuration GetDefaultConfiguration()
+		{
+			Configuration result = new Configuration();
+			if (hibernateConfigFile != null)
+			{
+				result.Configure(hibernateConfigFile);
+			}
+			return result;
+		}
+
+		/// <summary>
+		/// Gets the default configuration file path.
+		/// </summary>
+		/// <returns>
+		/// The default configuration file path.
+		/// </returns>
 		public static string GetDefaultConfigurationFilePath()
 		{
 			string baseDir = AppDomain.CurrentDomain.BaseDirectory;
 			string relativeSearchPath = AppDomain.CurrentDomain.RelativeSearchPath;
 			string binPath = relativeSearchPath == null ? baseDir : Path.Combine(baseDir, relativeSearchPath);
-			string fullPath = Path.Combine(binPath, Cfg.Configuration.DefaultHibernateCfgFileName);
+			string fullPath = Path.Combine(binPath, Configuration.DefaultHibernateCfgFileName);
 			return File.Exists(fullPath) ? fullPath : null;
-		}
-
-		/// <summary>
-		/// Standar Configuration for tests.
-		/// </summary>
-		/// <returns>The configuration using merge between App.Config and hibernate.cfg.xml if present.</returns>
-		public static Configuration GetDefaultConfiguration()
-		{
-			Configuration result = new Configuration();
-			if (hibernateConfigFile != null)
-				result.Configure(hibernateConfigFile);
-			return result;
 		}
 	}
 }

--- a/TestDialect.cs
+++ b/TestDialect.cs
@@ -1,71 +1,152 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Linq;
-using System.Text;
+
 using NHibernate.SqlTypes;
 
 namespace NHibernate.Test
 {
 	/// <summary>
-	/// Like NHibernate's Dialect class, but for differences only important during testing.
-	/// Defaults to true for all support.  Users of different dialects can turn support
-	/// off if the unit tests fail.
+	/// Like NHibernate's Dialect class, but for differences only important during testing. Defaults to true for all support.  Users
+	/// of different dialects can turn support off if the unit tests fail.
 	/// </summary>
 	public class TestDialect
 	{
+		private readonly Dialect.Dialect dialect;
+
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		/// <param name="dialect">The dialect.</param>
+		public TestDialect(Dialect.Dialect dialect)
+		{
+			this.dialect = dialect;
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether this object has broken decimal type.
+		/// </summary>
+		public virtual bool HasBrokenDecimalType
+		{
+			get { return false; }
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether this object ignores trailing whitespace.
+		/// </summary>
+		public virtual bool IgnoresTrailingWhitespace
+		{
+			get { return false; }
+		}
+
+		/// <summary>
+		/// Whether two transactions can be run at the same time.  For example, with SQLite the database is locked when one transaction
+		/// is run, so running a second transaction will cause a "database is locked" error message.
+		/// </summary>
+		public virtual bool SupportsConcurrentTransactions
+		{
+			get { return true; }
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether distributed transactions are supported. Requires the MSDTC service to be started if true.
+		/// </summary>
+		public virtual bool SupportsDistributedTransactions
+		{
+			get { return true; }
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether full joins are supported.
+		/// </summary>
+		public virtual bool SupportsFullJoin
+		{
+			get { return true; }
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether having without group by is supported.
+		/// </summary>
+		public virtual bool SupportsHavingWithoutGroupBy
+		{
+			get { return true; }
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether locate is supported.
+		/// </summary>
+		public virtual bool SupportsLocate
+		{
+			get { return true; }
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether null characters in utf strings is supported.
+		/// </summary>
+		public virtual bool SupportsNullCharactersInUtfStrings
+		{
+			get { return true; }
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether the all operator is supported.
+		/// </summary>
+		public virtual bool SupportsOperatorAll
+		{
+			get { return true; }
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether the some operator is supported.
+		/// </summary>
+		public virtual bool SupportsOperatorSome
+		{
+			get { return true; }
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether select for update on outer join is supported.
+		/// </summary>
+		public virtual bool SupportsSelectForUpdateOnOuterJoin
+		{
+			get { return true; }
+		}
+
+		/// <summary>
+		/// Gets a test dialect.
+		/// </summary>
+		/// <param name="dialect">The dialect.</param>
+		/// <returns>
+		/// The test dialect.
+		/// </returns>
 		public static TestDialect GetTestDialect(Dialect.Dialect dialect)
 		{
-			string testDialectTypeName = "NHibernate.Test.TestDialects." + dialect.GetType().Name.Replace("Dialect", "TestDialect");
+			string testDialectTypeName = "NHibernate.Test.TestDialects."
+			                             + dialect.GetType().Name.Replace("Dialect", "TestDialect");
 			System.Type testDialectType = System.Type.GetType(testDialectTypeName);
 			if (testDialectType != null)
+			{
 				return (TestDialect)Activator.CreateInstance(testDialectType, dialect);
+			}
 			return new TestDialect(dialect);
 		}
 
-	    private Dialect.Dialect dialect;
-
-        public TestDialect(Dialect.Dialect dialect)
-        {
-            this.dialect = dialect;
-        }
-
-		public virtual bool SupportsOperatorAll { get { return true; } }
-		public virtual bool SupportsOperatorSome { get { return true; } }
-		public virtual bool SupportsLocate { get { return true; } }
-
-		public virtual bool SupportsDistributedTransactions { get { return true; } }
-
 		/// <summary>
-		/// Whether two transactions can be run at the same time.  For example, with SQLite
-		/// the database is locked when one transaction is run, so running a second transaction
-		/// will cause a "database is locked" error message.
+		/// Whether or not the dialect supportts the given Sql Type.
 		/// </summary>
-		public virtual bool SupportsConcurrentTransactions { get { return true; } }
-
-		public virtual bool SupportsFullJoin { get { return true; } }
-
-        public virtual bool HasBrokenDecimalType { get { return false; } }
-
-        public virtual bool SupportsNullCharactersInUtfStrings { get { return true; } }
-
-        public virtual bool SupportsSelectForUpdateOnOuterJoin { get { return true; } }
-
-        public virtual bool SupportsHavingWithoutGroupBy { get { return true; } }
-
-        public virtual bool IgnoresTrailingWhitespace { get { return false; } }
-
-	    public bool SupportsSqlType(SqlType sqlType)
-	    {
-            try
-            {
-                dialect.GetTypeName(sqlType);
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
-	    }
+		/// <param name="sqlType">The Sql Type.</param>
+		/// <returns>
+		/// true if supported, false if not.
+		/// </returns>
+		public bool SupportsSqlType(SqlType sqlType)
+		{
+			try
+			{
+				this.dialect.GetTypeName(sqlType);
+				return true;
+			}
+			catch
+			{
+				return false;
+			}
+		}
 	}
 }


### PR DESCRIPTION
If you're interested, here's a code cleanup changeset. I realize it may not be acceptable since it'll mess with diffs, but I figured it might be welcome...
- There were mixed tabs and spaces - defaulted to tabs, since that seemed to be the most frequently used.
- Added "this" qualifier for clarity.
- Reordered methods and properties to be consistent.
- Added comments on all public and protected methods and properties.
- Minor typos.
